### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkErrorFunctionBase.h
+++ b/include/itkErrorFunctionBase.h
@@ -35,6 +35,8 @@ template<typename TMeasurementVector, typename TTargetVector>
 class ErrorFunctionBase : public FunctionBase<TMeasurementVector, TTargetVector>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ErrorFunctionBase);
+
   /** Standard class type alias. */
   using Self = ErrorFunctionBase;
   using Superclass = FunctionBase<TMeasurementVector, TTargetVector>;
@@ -63,7 +65,6 @@ protected:
 
 private:
 
-  ITK_DISALLOW_COPY_AND_ASSIGN(ErrorFunctionBase);
 };
 
 } // end namespace itk

--- a/include/itkInputFunctionBase.h
+++ b/include/itkInputFunctionBase.h
@@ -34,6 +34,7 @@ template<typename TMeasurementVector, typename TTargetVector>
 class InputFunctionBase : public FunctionBase<TMeasurementVector, TTargetVector>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(InputFunctionBase);
 
   /** Standard class type alias. */
   using Self = InputFunctionBase;
@@ -68,8 +69,6 @@ protected:
     }
 
 private:
-
-  ITK_DISALLOW_COPY_AND_ASSIGN(InputFunctionBase);
 
 };//class
 

--- a/include/itkNNetDistanceMetricBase.h
+++ b/include/itkNNetDistanceMetricBase.h
@@ -34,6 +34,7 @@ template<typename TMeasurementVector>
 class NNetDistanceMetricBase : public FunctionBase<TMeasurementVector, double>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(NNetDistanceMetricBase );
 
   /** Standard class type alias. */
   using Self = NNetDistanceMetricBase;
@@ -63,11 +64,6 @@ protected:
     os << indent << "NNetDistanceMetricBase(" << this << ")" << std::endl;
     Superclass::PrintSelf( os, indent );
     }
-
-private:
-
-  ITK_DISALLOW_COPY_AND_ASSIGN(NNetDistanceMetricBase );
-
 };
 
 } // end namespace Statistics

--- a/include/itkRadialBasisFunctionBase.h
+++ b/include/itkRadialBasisFunctionBase.h
@@ -35,6 +35,7 @@ template<typename ScalarType>
 class RadialBasisFunctionBase : public FunctionBase<ScalarType,ScalarType>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(RadialBasisFunctionBase);
 
   /** Standard class type alias. */
   using Self = RadialBasisFunctionBase;
@@ -81,7 +82,6 @@ private:
   ArrayType  m_Center;
   ScalarType m_Radius;
 
-  ITK_DISALLOW_COPY_AND_ASSIGN(RadialBasisFunctionBase);
 };
 
 } // end namespace Statistics

--- a/include/itkSquaredDifferenceErrorFunction.h
+++ b/include/itkSquaredDifferenceErrorFunction.h
@@ -36,6 +36,7 @@ template<typename TMeasurementVector, typename ScalarType>
 class ITK_TEMPLATE_EXPORT SquaredDifferenceErrorFunction : public ErrorFunctionBase<TMeasurementVector, ScalarType>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SquaredDifferenceErrorFunction);
 
   /** Standard class type alias. */
   using Self = SquaredDifferenceErrorFunction;
@@ -64,10 +65,6 @@ protected:
   ~SquaredDifferenceErrorFunction() override;
 
   void PrintSelf( std::ostream& os, Indent indent ) const override;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SquaredDifferenceErrorFunction);
-
 };
 
 } // end namespace Statistics

--- a/include/itkTransferFunctionBase.h
+++ b/include/itkTransferFunctionBase.h
@@ -35,6 +35,7 @@ template<typename ScalarType>
 class TransferFunctionBase : public FunctionBase<ScalarType, ScalarType>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(TransferFunctionBase);
 
   /** Standard class type alias. */
   using Self = TransferFunctionBase;
@@ -71,7 +72,6 @@ protected:
 
 private:
 
-  ITK_DISALLOW_COPY_AND_ASSIGN(TransferFunctionBase);
 };
 
 } // end namespace Statistics


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.